### PR TITLE
model card security code: comment out required properties

### DIFF
--- a/model_card_security_code_verification.go
+++ b/model_card_security_code_verification.go
@@ -116,8 +116,8 @@ func (o *CardSecurityCodeVerification) UnmarshalJSON(data []byte) (err error) {
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
 	requiredProperties := []string{
-		"response",
-		"type",
+		// "response",
+		// "type",
 	}
 
 	allProperties := make(map[string]interface{})


### PR DESCRIPTION
This help fix the unmarshal error for such object

```
"card_security_code_verification": {
    "response": {
      "code": "0000",
      "memo": "Card security code match"
    }
  },
```
where `type` is missing, so that it throws 422
```
{
  "field": "Payload",
  "source": "body",
  "value": null,
  "error": "no value given for required property type"
}
```