### PR TITLE
Add signature algorithm to webhook config serialization

### DIFF
--- a/model_webhook_config_model.go
+++ b/model_webhook_config_model.go
@@ -250,6 +250,9 @@ func (o WebhookConfigModel) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Secret) {
 		toSerialize["secret"] = o.Secret
 	}
+	if !IsNil(o.SignatureAlgorithm) {
+		toSerialize["signature_algorithm"] = o.SignatureAlgorithm
+	}
 	toSerialize["url"] = o.Url
 	if !IsNil(o.UseMtls) {
 		toSerialize["use_mtls"] = o.UseMtls


### PR DESCRIPTION
Include SignatureAlgorithm field in ToMap function to properly serialize the signature_algorithm field when sending webhook configuration to the Marqeta API.